### PR TITLE
Fix failing test

### DIFF
--- a/src/Bpp/Seq/Alphabet/CodonAlphabet.h
+++ b/src/Bpp/Seq/Alphabet/CodonAlphabet.h
@@ -73,6 +73,8 @@ namespace bpp
      * @brief Builds a new codon alphabet from a nucleic alphabet.
      * 
      * @param alpha The nucleic alphabet to be used.
+     *
+     * Takes ownership of the NucleicAlphabet object (dynamically allocated).
      */
     CodonAlphabet(const NucleicAlphabet* alpha) :
       AbstractAlphabet(),

--- a/test/test_alphabets.cpp
+++ b/test/test_alphabets.cpp
@@ -54,7 +54,7 @@ int main() {
   NucleicAlphabet* rna = new RNA();
   Alphabet* pro = new ProteicAlphabet;
   Alphabet* def = new DefaultAlphabet;
-  Alphabet* cdn = new CodonAlphabet(rna);
+  Alphabet* cdn = new CodonAlphabet(rna); // Takes ownership of rna
 
   //Testing functions:
   if (!AlphabetTools::isDNAAlphabet(dna)) return 1;
@@ -64,11 +64,10 @@ int main() {
   if (!AlphabetTools::isProteicAlphabet(pro)) return 1;
   if (!AlphabetTools::isCodonAlphabet(cdn)) return 1;
 
-  delete dna;
-  delete rna;
-  delete pro;
-  delete def;
   delete cdn;
+  delete def;
+  delete pro;
+  delete dna;
 
   return (0);
 }


### PR DESCRIPTION
CodonAlphabet took ownership of the NucleicAlphabet object.
(delete in destructor).
Long term fix is to upgrade these classes using C++11 smart pointers to
express ownership or lack of it.
delete in a virtual overridable destructor seems fragile...