### PR TITLE
fix some typos

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -24,4 +24,4 @@ Contributed code to Bio++ was enabled thanks to the following institutions and r
 2009 - 2010 Berkeley University (Bastien Boussau)
 2010 -      Laboratoire BBE - UMR CNRS 5558 Université Lyon 1 (Bastien Boussau)   
 2008 -      Laboratoire BBE - UMR CNRS 5558 Université Lyon 1 (Laurent Guéguen)
-2017 - 2018 Projet GrASP - LabEX Ecofect - Université de Lyon (François Gindraud)
+2017 - 2018 Project GrASP - LabEX Ecofect - Université de Lyon (François Gindraud)

--- a/ChangeLog
+++ b/ChangeLog
@@ -201,7 +201,7 @@ method.
   implemented by the Fasta class.
 
 17/08/09 Adam Smith
-* Bug fixed in DefaultAlphabet: unknow state is 37 not 38.
+* Bug fixed in DefaultAlphabet: unknown state is 37 not 38.
 
 04/08/09 Sylvain Gaillard
 * Introduced new classes for Alphabet States
@@ -213,7 +213,7 @@ method.
 * Added SequenceTools::getNumberOfUnresolvedSites
 * Updated SequenceTools::getNumberOfSites,
 	SequenceTools::getNumberOfCompleteSites and SequenceTools::removeGaps to be
-	Alphabet implementation independant.
+	Alphabet implementation independent.
 
 07/07/07 Julien Dutheil
 * Updated GranthamAAChemicalDistance, with a new signed, non-symmetric,
@@ -224,7 +224,7 @@ method.
 
 23/06/09 Julien Dutheil
 * Actualization of the Container classes: now returns references and not
-pointer. Several code updates, including copy contructors.
+pointer. Several code updates, including copy constructors.
 
 17/06/09 Sylvain Gaillard (Glasgow Workshop)
 * Fix DNA/RNA/ProteicAlphabet::getAlias: works now with lower case states.
@@ -294,7 +294,7 @@ pointer. Several code updates, including copy contructors.
   unsigned int).
 
 07/11/08 Julien Dutheil
-* New contructor in VectorSiteContainer now as a tag to disable position
+* New constructor in VectorSiteContainer now as a tag to disable position
   checking, which can turn to be quite slow.
 
 06/11/08 Sylvain Gaillard
@@ -374,12 +374,12 @@ pointer. Several code updates, including copy contructors.
 * Compatibility update (NumCalc)
 
 24/04/07 Benoît Nabholz & Julien Dutheil
-* GeneticCode classes can now translate unknow codons to unknown amino acids.
+* GeneticCode classes can now translate unknown codons to unknown amino acids.
 
 02/04/07 Julien Dutheil
 * VIRTUAL_COV variable changed to NO_VIRTUAL_COV. configure.ac file updated.
   => Default behaviour is now /really/ to use covariant return type with
-	virtual inheritence, even when importing the files in an IDE. To use the old
+	virtual inheritance, even when importing the files in an IDE. To use the old
 	compilers behaviour, one must set the NO_VIRTUAL_COV preproc variable.
 * this modification also solves a problem with the old configure.ac which
   was not correctly updated in version 1.2.0 :(
@@ -405,7 +405,7 @@ AlphabetIndex2 objects from AAIndex1 and AAIndex2 entries, respectively.
 
 18/12/06 Julien Dutheil
 * New alignment tools in SiteContainerTools, including the Needleman and
-Wunsch alogrithm.
+Wunsch algorithm.
 * BLOSUM50 matrix available.
 * Bug fixed in Sequence.h: method setContent is now properly redefined.
 * Bug fixed in ProteicAlphabet->getAbbr(int). The returned result is now

--- a/src/Bpp/Seq/Alphabet/AbstractAlphabet.h
+++ b/src/Bpp/Seq/Alphabet/AbstractAlphabet.h
@@ -21,7 +21,7 @@ namespace bpp
  * @brief A partial implementation of the Alphabet interface.
  *
  * It contains a vector of AlphabetState.
- * All methods are based uppon this vector
+ * All methods are based upon this vector
  * but do not provide any method to initialize it.
  * This is up to each constructor of the derived classes.
  *
@@ -140,7 +140,7 @@ public:
    * @brief Get a state at a position in the alphabet_ vector.
    *
    * This method must be overloaded in specialized classes to send back
-   * a reference of the corect type.
+   * a reference of the correct type.
    *
    * @param stateIndex The index of the state in the alphabet_ vector.
    * @throw IndexOutOfBoundsException If the index is invalid.
@@ -151,7 +151,7 @@ public:
    * @brief Get a state at a position in the alphabet_ vector.
    *
    * This method must be overloaded in specialized classes to send back
-   * a reference of the corect type.
+   * a reference of the correct type.
    *
    * @param stateIndex The index of the state in the alphabet_ vector.
    * @throw IndexOutOfBoundsException If the index is invalid.
@@ -162,7 +162,7 @@ public:
    * @brief Get a state by its letter.
    *
    * This method must be overloaded in specialized classes to send back
-   * a reference of the corect type.
+   * a reference of the correct type.
    *
    * @param letter The letter of the state to find.
    * @throw BadCharException If the letter is not in the Alphabet.
@@ -175,7 +175,7 @@ public:
    * @brief Get a state by its num.
    *
    * This method must be overloaded in specialized classes to send back
-   * a reference of the corect type.
+   * a reference of the correct type.
    *
    * @param num The num of the state to find.
    * @throw BadIntException If the num is not in the Alphabet.

--- a/src/Bpp/Seq/Alphabet/Alphabet.h
+++ b/src/Bpp/Seq/Alphabet/Alphabet.h
@@ -255,7 +255,7 @@ public:
    * @brief This is a convenient  alias for getNumberOfChars(), returning a size_t
    * instead of unsigned int.
    *
-   * This funcion is typically used il loops over all states of an alphabet.
+   * This function is typically used il loops over all states of an alphabet.
    */
   virtual size_t getNumberOfStates() const = 0;
 

--- a/src/Bpp/Seq/Alphabet/AlphabetTools.h
+++ b/src/Bpp/Seq/Alphabet/AlphabetTools.h
@@ -105,67 +105,67 @@ public:
   static unsigned int getAlphabetCodingSize(const Alphabet* alphabet);
 
   /**
-   * @return True if the alphabet is an instanciation of the NucleicAlphabet class.
+   * @return True if the alphabet is an instantiation of the NucleicAlphabet class.
    * @param alphabet The alphabet to check.
    */
   static bool isNucleicAlphabet(const Alphabet* alphabet) { return alphabetInheritsFrom<NucleicAlphabet>(alphabet); }
 
   /**
-   * @return True if the alphabet is an instanciation of the DNA class.
+   * @return True if the alphabet is an instantiation of the DNA class.
    * @param alphabet The alphabet to check.
    */
   static bool isDNAAlphabet(const Alphabet* alphabet) { return alphabetInheritsFrom<DNA>(alphabet); }
 
   /**
-   * @return True if the alphabet is an instanciation of the RNA class.
+   * @return True if the alphabet is an instantiation of the RNA class.
    * @param alphabet The alphabet to check.
    */
   static bool isRNAAlphabet(const Alphabet* alphabet) { return alphabetInheritsFrom<RNA>(alphabet); }
 
   /**
-   * @return True if the alphabet is an instanciation of the ProteicAlphabet class.
+   * @return True if the alphabet is an instantiation of the ProteicAlphabet class.
    * @param alphabet The alphabet to check.
    */
   static bool isProteicAlphabet(const Alphabet* alphabet) { return alphabetInheritsFrom<ProteicAlphabet>(alphabet); }
 
   /**
-   * @return True if the alphabet is an instanciation of the Codon class.
+   * @return True if the alphabet is an instantiation of the Codon class.
    * @param alphabet The alphabet to check.
    */
   static bool isCodonAlphabet(const Alphabet* alphabet) { return alphabetInheritsFrom<CodonAlphabet>(alphabet); }
 
   /**
-   * @return True if the alphabet is an instanciation of the WordAlphabet class.
+   * @return True if the alphabet is an instantiation of the WordAlphabet class.
    * @param alphabet The alphabet to check.
    */
   static bool isWordAlphabet(const Alphabet* alphabet) { return alphabetInheritsFrom<CoreWordAlphabet>(alphabet); }
 
   /**
-   * @return True if the alphabet is an instanciation of the RNY class.
+   * @return True if the alphabet is an instantiation of the RNY class.
    * @param alphabet The alphabet to check.
    */
   static bool isRNYAlphabet(const Alphabet* alphabet) { return alphabetInheritsFrom<RNY>(alphabet); }
 
   /**
-   * @return True if the alphabet is an instanciation of the BinaryAlphabet class.
+   * @return True if the alphabet is an instantiation of the BinaryAlphabet class.
    * @param alphabet The alphabet to check.
    */
   static bool isBinaryAlphabet(const Alphabet* alphabet) { return alphabetInheritsFrom<BinaryAlphabet>(alphabet); }
 
   /**
-   * @return True if the alphabet is an instanciation of the ProteicAlphabet class.
+   * @return True if the alphabet is an instantiation of the ProteicAlphabet class.
    * @param alphabet The alphabet to check.
    */
   static bool isIntegerAlphabet(const Alphabet* alphabet) { return alphabetInheritsFrom<IntegerAlphabet>(alphabet); }
 
   /**
-   * @return True if the alphabet is an instanciation of the DefaultAlphabet class.
+   * @return True if the alphabet is an instantiation of the DefaultAlphabet class.
    * @param alphabet The alphabet to check.
    */
   static bool isDefaultAlphabet(const Alphabet* alphabet) { return alphabetInheritsFrom<DefaultAlphabet>(alphabet); }
 
   /**
-   * @return True if the alphabet is an instanciation of the Allelic class.
+   * @return True if the alphabet is an instantiation of the Allelic class.
    * @param alphabet The alphabet to check.
    */
   static bool isAllelicAlphabet(const Alphabet* alphabet) { return alphabetInheritsFrom<AllelicAlphabet>(alphabet); }

--- a/src/Bpp/Seq/Alphabet/CodonAlphabet.h
+++ b/src/Bpp/Seq/Alphabet/CodonAlphabet.h
@@ -365,7 +365,7 @@ public:
    * @brief Translate a whole sequence from letters alphabet to words alphabet.
    *
    * @param sequence A sequence in letters alphabet.
-   * @param pos the start postion (default 0)
+   * @param pos the start position (default 0)
    * @return The corresponding sequence in words alphabet.
    * @throw AlphabetMismatchException If the sequence alphabet do not match the source alphabet.
    * @throw Exception                 Other kind of error, depending on the implementation.

--- a/src/Bpp/Seq/Alphabet/NucleicAlphabet.h
+++ b/src/Bpp/Seq/Alphabet/NucleicAlphabet.h
@@ -113,7 +113,7 @@ public:
    *
    * @param code The binary representation as an unsigned char.
    * @return The NucleicAlphabetState.
-   * @throw BadIntException If the code is not a valide state.
+   * @throw BadIntException If the code is not a valid state.
    * @author Sylvain Gaillard
    */
   const NucleicAlphabetState& getStateByBinCode(int code) const
@@ -141,7 +141,7 @@ public:
    *
    * @param s1 the first state as an int
    * @param s2 the second state as an int
-   * @throw BadIntException if one of the states is not valide.
+   * @throw BadIntException if one of the states is not valid.
    * @return The remaining state as an int
    * @author Sylvain Gaillard
    */
@@ -166,7 +166,7 @@ public:
    *
    * @param s1 the first state as a string
    * @param s2 the second state as a string
-   * @throw BadCharException if one of the states is not valide.
+   * @throw BadCharException if one of the states is not valid.
    * @return The remaining state as a string
    * @author Sylvain Gaillard
    */

--- a/src/Bpp/Seq/Alphabet/RNY.cpp
+++ b/src/Bpp/Seq/Alphabet/RNY.cpp
@@ -269,7 +269,7 @@ bool RNY::isResolvedIn(int state1, int state2) const
   case 7: // ---
     return state2 >= 0;
   default:
-    throw BadIntException(state1, "RNY:isResolvedIn : this sould not happen.", this);
+    throw BadIntException(state1, "RNY:isResolvedIn : this should not happen.", this);
   }
 }
 

--- a/src/Bpp/Seq/Alphabet/WordAlphabet.h
+++ b/src/Bpp/Seq/Alphabet/WordAlphabet.h
@@ -100,7 +100,7 @@ public:
    * @brief Translate a whole sequence from letters alphabet to words alphabet.
    *
    * @param sequence A sequence in letters alphabet.
-   * @param pos the start postion (default 0)
+   * @param pos the start position (default 0)
    * @return The corresponding sequence in words alphabet.
    * @throw AlphabetMismatchException If the sequence alphabet do not match the source alphabet.
    * @throw Exception                 Other kind of error, depending on the implementation.
@@ -415,7 +415,7 @@ public:
    * @brief Translate a whole sequence from letters alphabet to words alphabet.
    *
    * @param sequence A sequence in letters alphabet.
-   * @param pos the start postion (default 0)
+   * @param pos the start position (default 0)
    * @return The corresponding sequence in words alphabet.
    * @throw AlphabetMismatchException If the sequence alphabet do not match the source alphabet.
    * @throw Exception                 Other kind of error, depending on the implementation.

--- a/src/Bpp/Seq/AlphabetIndex/AAIndex2Entry.h
+++ b/src/Bpp/Seq/AlphabetIndex/AAIndex2Entry.h
@@ -28,7 +28,7 @@ public:
    * @param input The input stream to use.
    * @param sym Tell if the matrix is symmetric.
    * This option as an effect only if the matrix is specified as a triangle in the entry.
-   * If sym==true, the oher triangle will be built by symmetry.
+   * If sym==true, the other triangle will be built by symmetry.
    * If sym==false, the other triangle will be set to (-) the given triangle.
    * If the input matrix is square, it will be considered non-symetric.
    * @throw IOException if the stream content does not follow the AAIndex2 database entry format.

--- a/src/Bpp/Seq/AlphabetIndex/GranthamAAChemicalDistance.h
+++ b/src/Bpp/Seq/AlphabetIndex/GranthamAAChemicalDistance.h
@@ -23,7 +23,7 @@ namespace bpp
  * - a symmetric one, with \f$I_{i,j} = I_{i,j}\f$,
  * - or a non-symmetric one, with \f$I_{i,j} = -I_{i,j}\f$.
  * In the second case, which one of the two entries between \f$I_{i,j}\f$ and \f$I_{i,j}\f$ is positive is arbitrary by default.
- * It is also possible to use the coordinate on a principal component analysis between the elementary propoerties of the distance instead (setPC1Sign(true)).
+ * It is also possible to use the coordinate on a principal component analysis between the elementary properties of the distance instead (setPC1Sign(true)).
  * The following R code was use in order to get those signs:
  * @code
  * library(seqinr)

--- a/src/Bpp/Seq/App/SequenceApplicationTools.h
+++ b/src/Bpp/Seq/App/SequenceApplicationTools.h
@@ -307,7 +307,7 @@ public:
    * be changed to 'unknown' character is sequences.
    *
    * - sequence.max_gap_allowed = [57%|30]
-   * If a % sign fallow the number, it is taken to be a frequence (in percent).
+   * If a % sign follows the number, it is taken to be a frequence (in percent).
    * This specify the maximum amount of gaps allowed for each site.
    * Sites not satisfying this amount will be removed.
    * A value of 100% will remove all gap-only sites, a value >100% will keep all sites.

--- a/src/Bpp/Seq/CodonSiteTools.cpp
+++ b/src/Bpp/Seq/CodonSiteTools.cpp
@@ -65,7 +65,7 @@ bool CodonSiteTools::isMonoSitePolymorphic(const Site& site)
   // Global polymorphism checking
   if (SymbolListTools::isConstant(site))
     return false;
-  // initialisation of the 3 sub-sites ot the codon
+  // initialisation of the 3 sub-sites of the codon
   vector<int> pos1, pos2, pos3;
   auto ca = dynamic_pointer_cast<const CodonAlphabet>(site.getAlphabet());
   for (size_t i = 0; i < site.size(); i++)

--- a/src/Bpp/Seq/CodonSiteTools.h
+++ b/src/Bpp/Seq/CodonSiteTools.h
@@ -70,7 +70,7 @@ public:
    *
    * @param site a Site
    * @param gCode The genetic code according to which stop codons are specified.
-   * @param freqmin a double, allele in frequency stricly lower than freqmin are replaced
+   * @param freqmin a double, allele in frequency strictly lower than freqmin are replaced
    */
   static std::unique_ptr<Site> generateCodonSiteWithoutRareVariant(const Site& site, const GeneticCode& gCode, double freqmin);
 
@@ -104,7 +104,7 @@ public:
    * @f[
    * pi = \frac{n}{n-1}\sum_{i,j}x_{i}x_{j}P_{ij}
    * @f]
-   * where n is the number of sequence, \f$x_i\f$ and \f$x_j\f$ the frequencies of each codon type occuring at the site
+   * where n is the number of sequence, \f$x_i\f$ and \f$x_j\f$ the frequencies of each codon type occurring at the site
    * \f$P_{i,j}\f$ the number of synonymous difference between these codons.
    * Be careful: here, pi is not normalized by the number of synonymous sites.
    *
@@ -124,7 +124,7 @@ public:
    * @f[
    * pi = \frac{n}{n-1}\sum_{i,j}x_{i}x_{j}P_{ij}
    * @f]
-   * where n is the number of sequence, \f$x_i\f$ and \f$x_j\f$ the frequencies of each codon type occuring at the site
+   * where n is the number of sequence, \f$x_i\f$ and \f$x_j\f$ the frequencies of each codon type occurring at the site
    * \f$P_{i,j}\f$ the number of nonsynonymous difference between these codons.
    * Be careful: here, pi is not normalized by the number of non-synonymous sites.
    * If minchange = false (default option) the different paths are equally weighted.
@@ -166,7 +166,7 @@ public:
   static double meanNumberOfSynonymousPositions(const Site& site, const GeneticCode& gCode, double ratio = 1);
 
   /**
-   * @brief Return the number of subsitutions per codon site
+   * @brief Return the number of substitutions per codon site
    *
    * No recombination is assumed, that is in complex codon homoplasy is assumed.
    * Example:
@@ -181,7 +181,7 @@ public:
    * AGC
    * @endcode
    * Here, 3 substitutions are counted. Assuming that the last codon (AGC) is a recombinant between ATC and AGT
-   * would have lead to counting only 2 subsitutions.
+   * would have lead to counting only 2 substitutions.
    *
    * Rare variants (<= freqmin) can be excluded.
    *
@@ -192,7 +192,7 @@ public:
   static size_t numberOfSubstitutions(const Site& site, const GeneticCode& gCode, double freqmin = 0.);
 
   /**
-   * @brief Return the number of Non Synonymous subsitutions per codon site.
+   * @brief Return the number of Non Synonymous substitutions per codon site.
    *
    * It is assumed that the path linking amino acids only involved one substitution by step.
    *
@@ -211,7 +211,7 @@ public:
    * @brief Return a vector with the number of fixed synonymous and non-synonymous differences per codon site
    *
    * Compute the number of synonymous and non-synonymous differences between
-   * the concensus codon of SiteIn (i) and SiteOut (j), which are fixed within each alignement.
+   * the consensus codon of SiteIn (i) and SiteOut (j), which are fixed within each alignment.
    * Example:
    * @code
    * SiteIn

--- a/src/Bpp/Seq/Container/AlignedSequenceContainer.h
+++ b/src/Bpp/Seq/Container/AlignedSequenceContainer.h
@@ -122,7 +122,7 @@ public:
   /**
    * @brief Try to coerce a SequenceContainer object into an AlignedSequenceContainer object.
    *
-   * Sequences in osc will be considered alligned, and have the same number of sites.
+   * Sequences in osc will be considered aligned, and have the same number of sites.
    *
    * @param sc The ordered container to coerce.
    * @throw SequenceNotAlignedException If sequences in sc do not have the same length.
@@ -500,7 +500,7 @@ public:
     else
       throw SequenceNotAlignedException("AlignedSequenceContainer::setSequence", sequencePtr.get());
 
-    // Detroys all sites (but keep Site Container at same size)
+    // Destroys all sites (but keep Site Container at same size)
     siteVector_.nullify();
   }
 
@@ -517,7 +517,7 @@ public:
     else
       throw SequenceNotAlignedException("AlignedSequenceContainer::setSequence", sequencePtr.get());
 
-    // Detroys all sites (but keep Site Container at same size)
+    // Destroys all sites (but keep Site Container at same size)
     siteVector_.nullify();
   }
 
@@ -534,7 +534,7 @@ public:
     else
       throw SequenceNotAlignedException("AlignedSequenceContainer::insertSequence", sequencePtr.get());
 
-    // Detroys all sites (but keep Site Container at same size)
+    // Destroys all sites (but keep Site Container at same size)
     siteVector_.nullify();
   }
 

--- a/src/Bpp/Seq/Container/CompressedVectorSiteContainer.cpp
+++ b/src/Bpp/Seq/Container/CompressedVectorSiteContainer.cpp
@@ -458,7 +458,7 @@ const Sequence& CompressedVectorSiteContainer::sequence(size_t sequencePosition)
   if (sequencePosition >= getNumberOfSequences())
     throw IndexOutOfBoundsException("CompressedVectorSiteContainer::getSequence.", sequencePosition, 0, getNumberOfSequences() - 1);
 
-  // If Sequence already exsits
+  // If Sequence already exists
   auto name = sequenceContainer_.getObjectName(sequencePosition);
   if (!sequenceContainer_.isAvailableName(name))
     return *sequenceContainer_.getObject(sequencePosition);

--- a/src/Bpp/Seq/Container/CompressedVectorSiteContainer.h
+++ b/src/Bpp/Seq/Container/CompressedVectorSiteContainer.h
@@ -31,7 +31,7 @@ namespace bpp
  * The number of sequences is fixed after the first site has been added.
  *
  * @warning Since the data is compressed, the sites given as input are modified. The
- * major pratical consequence is that the 'position' attribute of sites will be lost.
+ * major practical consequence is that the 'position' attribute of sites will be lost.
  * Instead, the position will correspond to the position in the compressed container.
  * In addition, this container may lead to unexpected behavior if used with derived
  * classes of Site.

--- a/src/Bpp/Seq/Container/SequenceContainer.h
+++ b/src/Bpp/Seq/Container/SequenceContainer.h
@@ -38,7 +38,7 @@ public:
   /**
    * @brief Return a copy of this container, but with no data inside.
    *
-   * This method creates a new SequencedContainer objet.
+   * This method creates a new SequencedContainer object.
    * The class of this container depends on the class implementing this interface.
    *
    * @return A new empty container, with the same alphabet as this one.
@@ -63,7 +63,7 @@ public:
   /**
    * @brief Replace a sequence in the container.
    *
-   * If a sequence is found with the given key, it will be udated with the new one.
+   * If a sequence is found with the given key, it will be updated with the new one.
    * If no sequence with the given key is found, the new sequence will be added to the container.
    *
    * @param sequenceKey The key to which the sequence is associated.
@@ -90,7 +90,7 @@ public:
   virtual std::unique_ptr<SequenceType> removeSequence(const HashType& sequenceKey) = 0;
 
   /**
-   * @brief Get the content of the dataset at a specific position (sequence key, site postion).
+   * @brief Get the content of the dataset at a specific position (sequence key, site position).
    *
    * @param sequenceKey key of the sequence in the container
    * @param sitePosition  index of the site
@@ -99,7 +99,7 @@ public:
   virtual const typename SequenceType::ElementType& valueAt(const HashType& sequenceKey, size_t sitePosition) const = 0;
 
   /**
-   * @brief Get the content of the dataset at a specific position (sequence key, site postion).
+   * @brief Get the content of the dataset at a specific position (sequence key, site position).
    *
    * @param sequenceKey key of the sequence in the container
    * @param sitePosition  index of the site
@@ -160,7 +160,7 @@ public:
   virtual std::unique_ptr<SequenceType> removeSequence(size_t sequencePosition) = 0;
 
   /**
-   * @brief Get the content of the dataset at a specific position (sequence position, site postion).
+   * @brief Get the content of the dataset at a specific position (sequence position, site position).
    *
    * @param sequencePosition index of the sequence in the container
    * @param sitePosition  index of the site
@@ -169,7 +169,7 @@ public:
   virtual const typename SequenceType::ElementType& valueAt(size_t sequencePosition, size_t sitePosition) const = 0;
 
   /**
-   * @brief Get the content of the dataset at a specific position (sequence position, site postion).
+   * @brief Get the content of the dataset at a specific position (sequence position, site position).
    *
    * @param sequencePosition index of the sequence in the container
    * @param sitePosition  index of the site

--- a/src/Bpp/Seq/Container/SequenceContainerTools.h
+++ b/src/Bpp/Seq/Container/SequenceContainerTools.h
@@ -141,7 +141,7 @@ public:
    *
    * @author Julien Dutheil
    *
-   * @param sequences The container from wich sequences are to be taken.
+   * @param sequences The container from which sequences are to be taken.
    * @param selection The positions of all sequences to retrieve.
    * @param outputCont A container where the selection should be added.
    * @throw Exception In case of bad sequence name, alphabet mismatch, etc.
@@ -170,7 +170,7 @@ public:
    *
    * @author Julien Dutheil
    *
-   * @param sequences The container from wich sequences are to be taken.
+   * @param sequences The container from which sequences are to be taken.
    * @param selection The names of all sequences to retrieve.
    * @param outputCont A container where the selection should be added.
    * @param strict If yes, trying to select a sequence that is not present
@@ -211,7 +211,7 @@ public:
    * Sequences are specified by their position, beginning at 0.
    * Redundant selection is not checked, so be careful with what you're doing!
    *
-   * @param sequences The container from wich sequences are to be taken.
+   * @param sequences The container from which sequences are to be taken.
    * @param selection The positions of all sequences to retrieve.
    * @return A new container with all selected sequences.
    */

--- a/src/Bpp/Seq/Container/SequenceData.h
+++ b/src/Bpp/Seq/Container/SequenceData.h
@@ -114,7 +114,7 @@ public:
   /**
    * @brief Return a copy of this container, but with no data inside.
    *
-   * This method creates a new SequencedContainer objet.
+   * This method creates a new SequencedContainer object.
    * The class of this container depends on the class implementing this interface.
    *
    * @return A new empty container, with the same alphabet as this one.

--- a/src/Bpp/Seq/Container/SequencedValuesContainer.h
+++ b/src/Bpp/Seq/Container/SequencedValuesContainer.h
@@ -145,7 +145,7 @@ public:
   /**
    * @brief Return a copy of this container, but with no data inside.
    *
-   * This method creates a new SequencedValuesContainer objet.
+   * This method creates a new SequencedValuesContainer object.
    * The class of this container depends on the derivative class.
    *
    * @return A new empty container, with the same alphabet as this one.

--- a/src/Bpp/Seq/Container/SiteContainer.h
+++ b/src/Bpp/Seq/Container/SiteContainer.h
@@ -40,7 +40,7 @@ public:
    * @brief Get a site from the container.
    *
    * @param sitePosition The position of the site in the container.
-   * @return A site objet corresponding to site i in the alignment.
+   * @return A site object corresponding to site i in the alignment.
    * @throw IndexOutOfBoundsException If the specified site does not exists.
    */
   virtual const SiteType& site(size_t sitePosition) const override = 0;

--- a/src/Bpp/Seq/Container/SiteContainerTools.h
+++ b/src/Bpp/Seq/Container/SiteContainerTools.h
@@ -72,7 +72,7 @@ public:
    * @brief Retrieves complete sites.
    *
    * This function builds a new VectorSiteContainer instance with only complete sites,
-   * i.e. site with fully resolved states (no gap, no unknown caracters).
+   * i.e. site with fully resolved states (no gap, no unknown characters).
    * The container passed as input is not modified, all sites are copied.
    *
    * @param sites The container to analyse.
@@ -377,7 +377,7 @@ public:
    *
    * Sites are specified by their indice, beginning at 0. Sites may be selected multiple times.
    *
-   * @param sites       The container from wich sequences are to be taken.
+   * @param sites       The container from which sequences are to be taken.
    * @param selection   The positions of all sites to retrieve.
    * @param outputSites A container where to add the selected sites. The container must have the same alphabet, number of sequences and sequence keys from the input container.
    */
@@ -401,7 +401,7 @@ public:
    *
    * Sites are specified by their indice, beginning at 0. Sites may be selected multiple times.
    *
-   * @param sites       The container from wich sequences are to be taken.
+   * @param sites       The container from which sequences are to be taken.
    * @param selection   The positions of all sites to retrieve.
    * @return A VectorSiteContainer with the selected sites. Comments from the original container will be copied.
    */
@@ -425,7 +425,7 @@ public:
    * Sites are specified by their indice, beginning at 0. Sites may be selected multiple times.
    * This version takes as input a generic AlignmentData object, and will try various casts.
    *
-   * @param sites       The container from wich sequences are to be taken.
+   * @param sites       The container from which sequences are to be taken.
    * @param selection   The positions of all sites to retrieve.
    * @return A container of the same type as the input one, with the selected sites. Comments from the original container will be copied.
    */
@@ -462,7 +462,7 @@ public:
    * are converted to site positions given the length of the words
    * of the alphabet.
    *
-   * @param sites       The container from wich sequences are to be taken.
+   * @param sites       The container from which sequences are to be taken.
    * @param selection   The positions to retrieve.
    * @param outputSites A container where to add the selected positions. The container must have the same alphabet, number of sequences and sequence keys from the input container.
    */
@@ -506,7 +506,7 @@ public:
    * are converted to site positions given the length of the words
    * of the alphabet.
    *
-   * @param sites       The container from wich sequences are to be taken.
+   * @param sites       The container from which sequences are to be taken.
    * @param selection   The positions of all sites to retrieve.
    * @return A VectorSiteContainer with the selected positions. Comments from the original container will be copied.
    */
@@ -626,7 +626,7 @@ public:
    * Position numbers start at 1.
    *
    * @param seq The sequence to translate.
-   * @return A map with original alignement positions as keys, and translated positions as values.
+   * @return A map with original alignment positions as keys, and translated positions as values.
    */
   static std::map<size_t, size_t> getAlignmentPositions(const Sequence& seq);
 
@@ -645,15 +645,15 @@ public:
   /** @} */
 
   /**
-   * @brief Translate alignement positions from an aligned sequence to the same sequence in a different alignment.
+   * @brief Translate alignment positions from an aligned sequence to the same sequence in a different alignment.
    *
    * Takes each position (starting at 1) in sequence 1, and look for the corresponding position in sequence 2.
    * The two sequences must be the same, excepted for the gaps.
-   * If no sequence contains gaps, or if the gaps are at the same place in both sequences, the translated postion will be the same as the original positions.
+   * If no sequence contains gaps, or if the gaps are at the same place in both sequences, the translated position will be the same as the original positions.
    *
    * @param seq1 The sequence to translate.
    * @param seq2 The reference sequence.
-   * @return A map with original alignement positions as keys, and translated positions as values.
+   * @return A map with original alignment positions as keys, and translated positions as values.
    * @throw AlphabetMismatchException If the sequences do not share the same alphabet.
    * @throw Exception If the sequence do not match.
    */
@@ -880,12 +880,12 @@ public:
   static const std::string SIMILARITY_NOGAP;
 
   /**
-   * @brief Add the content of a site container to an exhisting one.
+   * @brief Add the content of a site container to an existing one.
    *
    * The input containers are supposed to have unique sequence names.
    * If it is not the case, several things can happen:
    * - If the two containers have exactly the same keys in the same order, then the content of the second one will be added as is to the first one.
-   * - If the second container does not have exactly the same sequences keys or in a different order, then a reordered selection of the second contianer is created first,
+   * - If the second container does not have exactly the same sequences keys or in a different order, then a reordered selection of the second container is created first,
    *   and in that case, only the first sequence with a given name will be used and duplicated.
    * In any case, note that the second container should always contains all the sequence names from the first one,
    * otherwise an exception will be thrown.

--- a/src/Bpp/Seq/Container/VectorSequenceContainer.h
+++ b/src/Bpp/Seq/Container/VectorSequenceContainer.h
@@ -65,7 +65,7 @@ public:
   {}
 
   /**
-   * @name Copy contructors:
+   * @name Copy constructors:
    *
    * @{
    */

--- a/src/Bpp/Seq/Container/VectorSiteContainer.h
+++ b/src/Bpp/Seq/Container/VectorSiteContainer.h
@@ -511,7 +511,7 @@ public:
     if (sequencePosition >= getNumberOfSequences())
       throw IndexOutOfBoundsException("TemplateVectorSiteContainer::getSequence.", sequencePosition, 0, getNumberOfSequences() - 1);
 
-    // If Sequence already exsits
+    // If Sequence already exists
     auto name = sequenceContainer_.getObjectName(sequencePosition);
     if (!sequenceContainer_.isAvailableName(name))
     {

--- a/src/Bpp/Seq/CoreSymbolList.h
+++ b/src/Bpp/Seq/CoreSymbolList.h
@@ -99,7 +99,7 @@ public:
   /**
    * @name Provide direct access to the list content.
    *
-   * @warning These operators allow you to modifiy the list content.
+   * @warning These operators allow you to modify the list content.
    * No alphabet checking is performed for your modifications, so use with care, or
    * consider using the setContent() method.
    *
@@ -165,7 +165,7 @@ public:
    * @brief Set the whole content of the list.
    *
    * @param list The new content of the list.
-   * @see The list constructor for information about the way lists are internaly stored.
+   * @see The list constructor for information about the way lists are internally stored.
    */
   virtual void setContent(const std::vector<T>& list) = 0;
 
@@ -189,7 +189,7 @@ public:
   /**
    * @brief Add a character at a certain position in the list.
    *
-   * @param pos The postion where to insert the element.
+   * @param pos The position where to insert the element.
    * @param c   The character to add.
    */
   virtual void addElement(size_t pos, const T& c) = 0;
@@ -214,7 +214,7 @@ public:
   /**
    * @name Provide direct access to the list content.
    *
-   * @warning These operators allow you to modifiy the list content.
+   * @warning These operators allow you to modify the list content.
    * No alphabet checking is performed for your modifications, so use with care, or
    * consider using the setContent() method.
    *

--- a/src/Bpp/Seq/GeneticCode/GeneticCode.h
+++ b/src/Bpp/Seq/GeneticCode/GeneticCode.h
@@ -235,7 +235,7 @@ public:
    * @brief Get the subsequence corresponding to the coding part of a given sequence.
    *
    * If lookForInitCodon if set to 'true', the subsequence will start at the first AUG motif,
-   * otherwise the subsequence will start at the begining of the sequence.
+   * otherwise the subsequence will start at the beginning of the sequence.
    * The subsequence ends at the first stop codon (excluded) found, or the end of the sequence.
    *
    * The sequence may have a nucleotide or codon alphabet.

--- a/src/Bpp/Seq/IntSymbolList.h
+++ b/src/Bpp/Seq/IntSymbolList.h
@@ -48,7 +48,7 @@ public:
    * @brief Set the whole content of the list.
    *
    * @param list The new content of the list.
-   * @see The list constructor for information about the way lists are internaly stored.
+   * @see The list constructor for information about the way lists are internally stored.
    */
   virtual void setContent(const std::vector<std::string>& list) = 0;
 
@@ -70,7 +70,7 @@ public:
   /**
    * @brief Add a character at a certain position in the list.
    *
-   * @param pos The postion where to insert the element.
+   * @param pos The position where to insert the element.
    * @param c   The character to add, given as a string.
    */
   virtual void addElement(size_t pos, const std::string& c) = 0;
@@ -108,7 +108,7 @@ public:
  */
 class IntSymbolList :
   public virtual IntSymbolListInterface,
-  public virtual AbstractTemplateSymbolList<int> // This needs to be virtual because of diamond inheritence
+  public virtual AbstractTemplateSymbolList<int> // This needs to be virtual because of diamond inheritance
 {
 public:
   IntSymbolList(std::shared_ptr<const Alphabet> alpha) :

--- a/src/Bpp/Seq/Io/AbstractIAlignment.h
+++ b/src/Bpp/Seq/Io/AbstractIAlignment.h
@@ -138,7 +138,7 @@ protected:
  */
 class AbstractIAlignment2 :
   public virtual AbstractIAlignment,
-  // In case of diamond inheritence
+  // In case of diamond inheritance
   public virtual ISequence
 {
 public:
@@ -288,7 +288,7 @@ protected:
 
 class AbstractIProbabilisticAlignment2 :
   public virtual AbstractIProbabilisticAlignment,
-  // In case of diamond inheritence
+  // In case of diamond inheritance
   public virtual IProbabilisticSequence
 {
 public:

--- a/src/Bpp/Seq/Io/AbstractOSequence.h
+++ b/src/Bpp/Seq/Io/AbstractOSequence.h
@@ -53,7 +53,7 @@ public:
  */
 class AbstractOSequence2 :
   public virtual AbstractOSequence,
-  // in case for Diamond inheritence
+  // in case for Diamond inheritance
   public virtual OAlignment
 {
 public:

--- a/src/Bpp/Seq/Io/BppOAlignmentReaderFormat.h
+++ b/src/Bpp/Seq/Io/BppOAlignmentReaderFormat.h
@@ -42,7 +42,7 @@ public:
    *
    * @param description A string describing the reader in the keyval syntax.
    * @return A new IAlignment object according to options specified.
-   * @throw Exception if an error occured.
+   * @throw Exception if an error occurred.
    */
   std::unique_ptr<IAlignment> read(const std::string& description);
 

--- a/src/Bpp/Seq/Io/BppOAlignmentWriterFormat.h
+++ b/src/Bpp/Seq/Io/BppOAlignmentWriterFormat.h
@@ -44,7 +44,7 @@ public:
    *
    * @param description A string describing the reader in the keyval syntax.
    * @return A new OAlignment object according to options specified.
-   * @throw Exception if an error occured.
+   * @throw Exception if an error occurred.
    */
   std::unique_ptr<OAlignment> read(const std::string& description);
 

--- a/src/Bpp/Seq/Io/BppOAlphabetIndex1Format.h
+++ b/src/Bpp/Seq/Io/BppOAlphabetIndex1Format.h
@@ -18,7 +18,7 @@ namespace bpp
 /**
  * @brief AlphabetIndex1 I/O in BppO format.
  *
- * Enables the instanciation of AlphabetIndex1 objects according to
+ * Enables the instantiation of AlphabetIndex1 objects according to
  * the BppO syntax (see the Bio++ Program Suite
  * manual for a detailed description of this syntax).
  *
@@ -36,7 +36,7 @@ private:
 public:
   /**
    * @param alphabet The alphabet for which indices should be built.
-   * The alphabet will be used to check that the instanciated index is compatible.
+   * The alphabet will be used to check that the instantiated index is compatible.
    * @param message Some text describing what the index is intended for.
    * @param verbose Tell if some messages should be printed while parsing.
    */
@@ -90,7 +90,7 @@ public:
    *
    * @param description A string describing the index in the keyval syntax.
    * @return A new AlphabetIndex1 object according to options specified.
-   * @throw Exception if an error occured.
+   * @throw Exception if an error occurred.
    */
   std::unique_ptr<AlphabetIndex1> read(const std::string& description);
 };

--- a/src/Bpp/Seq/Io/BppOAlphabetIndex2Format.h
+++ b/src/Bpp/Seq/Io/BppOAlphabetIndex2Format.h
@@ -18,7 +18,7 @@ namespace bpp
 /**
  * @brief AlphabetIndex2 I/O in BppO format.
  *
- * Enables the instanciation of AlphabetIndex2 objects according to
+ * Enables the instantiation of AlphabetIndex2 objects according to
  * the BppO syntax (see the Bio++ Program Suite
  * manual for a detailed description of this syntax).
  *
@@ -36,7 +36,7 @@ private:
 public:
   /**
    * @param alphabet The alphabet for which indices should be built.
-   * The alphabet will be used to check that the instanciated index is compatible.
+   * The alphabet will be used to check that the instantiated index is compatible.
    * @param message Some text describing what the index is intended for.
    * @param verbose Tell if some messages should be printed while parsing.
    */
@@ -90,7 +90,7 @@ public:
    *
    * @param description A string describing the index in the keyval syntax.
    * @return A new AlphabetIndex2 object according to options specified.
-   * @throw Exception if an error occured.
+   * @throw Exception if an error occurred.
    */
   std::unique_ptr<AlphabetIndex2> read(const std::string& description);
 };

--- a/src/Bpp/Seq/Io/BppOSequenceReaderFormat.h
+++ b/src/Bpp/Seq/Io/BppOSequenceReaderFormat.h
@@ -43,7 +43,7 @@ public:
    *
    * @param description A string describing the reader in the keyval syntax.
    * @return A new ISequence object according to options specified.
-   * @throw Exception if an error occured.
+   * @throw Exception if an error occurred.
    */
   std::unique_ptr<ISequence> read(const std::string& description);
 

--- a/src/Bpp/Seq/Io/BppOSequenceStreamReaderFormat.h
+++ b/src/Bpp/Seq/Io/BppOSequenceStreamReaderFormat.h
@@ -41,7 +41,7 @@ public:
    *
    * @param description A string describing the reader in the keyval syntax.
    * @return A new ISequenceStream object according to options specified.
-   * @throw Exception if an error occured.
+   * @throw Exception if an error occurred.
    */
   std::unique_ptr<ISequenceStream> read(const std::string& description);
 

--- a/src/Bpp/Seq/Io/BppOSequenceWriterFormat.h
+++ b/src/Bpp/Seq/Io/BppOSequenceWriterFormat.h
@@ -42,7 +42,7 @@ public:
    *
    * @param description A string describing the reader in the keyval syntax.
    * @return A new OSequence object according to options specified.
-   * @throw Exception if an error occured.
+   * @throw Exception if an error occurred.
    */
   std::unique_ptr<OSequence> read(const std::string& description);
 

--- a/src/Bpp/Seq/Io/Clustal.cpp
+++ b/src/Bpp/Seq/Io/Clustal.cpp
@@ -51,7 +51,7 @@ void Clustal::appendAlignmentFromStream(std::istream& input, SequenceContainerIn
       count = 0;
   }
   if (beginSeq == 0)
-    throw IOException("Clustal::read. Bad intput file.");
+    throw IOException("Clustal::read. Bad input file.");
 
   unsigned int countSequences = 0;
 
@@ -75,7 +75,7 @@ void Clustal::appendAlignmentFromStream(std::istream& input, SequenceContainerIn
     {
       // Complete sequences
       if (TextTools::isEmpty(lineRead))
-        throw IOException("Clustal::read. Bad intput file.");
+        throw IOException("Clustal::read. Bad input file.");
       sequences[i]->append(lineRead.substr(beginSeq));
       getline(input, lineRead, '\n');
     }

--- a/src/Bpp/Seq/Io/Fasta.cpp
+++ b/src/Bpp/Seq/Io/Fasta.cpp
@@ -31,7 +31,7 @@ bool Fasta::nextSequence(istream& input, Sequence& seq) const
     if (input.eof())
       c = '\n';
 
-    // Sequence begining detection
+    // Sequence beginning detection
     if (c == '>')
     {
       // Stop if find a new sequence

--- a/src/Bpp/Seq/Io/IoSequence.h
+++ b/src/Bpp/Seq/Io/IoSequence.h
@@ -17,7 +17,7 @@ namespace bpp
 /**
  * @brief The IOSequence interface.
  *
- * Interface for sequences input/ouput.
+ * Interface for sequences input/output.
  */
 class IOSequence : public virtual IOFormat
 {
@@ -32,7 +32,7 @@ public:
 /**
  * @brief The IOProbabislisticSequence interface.
  *
- * Interface for probabilistic sequences input/ouput.
+ * Interface for probabilistic sequences input/output.
  */
 class IOProbabilisticSequence : public virtual IOFormat
 {

--- a/src/Bpp/Seq/Io/Mase.cpp
+++ b/src/Bpp/Seq/Io/Mase.cpp
@@ -118,7 +118,7 @@ void Mase::writeSequences(ostream& output, const SequenceContainerInterface& sc)
     comments = sc.sequence(seqKey).getComments();
 
     // Writing all sequence comments in file
-    // If no comments are associated with current sequence, an empy commentary line will be writed
+    // If no comments are associated with current sequence, an empty commentary line will be writed
     if (comments.size() == 0)
     {
       output << ";" << endl;

--- a/src/Bpp/Seq/Io/Mase.h
+++ b/src/Bpp/Seq/Io/Mase.h
@@ -207,7 +207,7 @@ public:
 
   const std::string getFormatDescription() const override
   {
-    return "Optional file comments (preceeded by ;;), sequence comments (preceeded by ;), sequence name, sequence";
+    return "Optional file comments (preceded by ;;), sequence comments (preceded by ;), sequence name, sequence";
   }
   /** @} */
 

--- a/src/Bpp/Seq/Io/MaseTools.h
+++ b/src/Bpp/Seq/Io/MaseTools.h
@@ -17,7 +17,7 @@ namespace bpp
 /**
  * @brief Utilitary methods that deal with the Mase format.
  *
- * This class particularily covers the Mase+ format, which allows
+ * This class particularly covers the Mase+ format, which allows
  * site and sequence selection.
  * Mase+ tags are in the header of the mase file, which is stored
  * in the 'general comment' section of sequence containers.

--- a/src/Bpp/Seq/Io/NexusTools.h
+++ b/src/Bpp/Seq/Io/NexusTools.h
@@ -34,7 +34,7 @@ public:
    *
    * @param input     [in]  The input stream.
    * @param name      [out] Will contain the name of the command.
-   * @param arguments [out] Will contain the arguments of the commans, as raw data. The arguments will not be parsed.
+   * @param arguments [out] Will contain the arguments of the commands, as raw data. The arguments will not be parsed.
    * @param lineBrk   [in]  Tell is the line break should be preserved in the arguments.
    * @return Whether a command was found in the current block.
    * @throw IOException In case of bad format.

--- a/src/Bpp/Seq/Io/PhredPhd.h
+++ b/src/Bpp/Seq/Io/PhredPhd.h
@@ -70,7 +70,7 @@ public:
    * the position of each base call on the chromatogram in a vector of
    * int.
    *
-   * @param input The stram to read.
+   * @param input The stream to read.
    * @param seq The sequence to fill.
    * @param pos The vector of positions to fill.
    * @throw Exception IOException and Sequence related exceptions.

--- a/src/Bpp/Seq/Io/Phylip.h
+++ b/src/Bpp/Seq/Io/Phylip.h
@@ -90,7 +90,7 @@ public:
   /**
    * @return The number of sequences contained in the specified file.
    *
-   * This methods parses the firt line of the phylip file.
+   * This methods parses the first line of the phylip file.
    * @param path The path of the file to parse.
    */
   unsigned int getNumberOfSequences(const std::string& path) const;

--- a/src/Bpp/Seq/ProbabilisticSequence.h
+++ b/src/Bpp/Seq/ProbabilisticSequence.h
@@ -46,7 +46,7 @@ public:
  *
  * This is a general purpose container, containing an ordered list of
  * elements.  The states represented by the elements is defined by an
- * alphabet object, which is passed to the contructor by a pointer.
+ * alphabet object, which is passed to the constructor by a pointer.
  *
  * ProbabilisticSequence objects also contain a name attribute and
  * potentially several comment lines.
@@ -56,7 +56,7 @@ public:
 class ProbabilisticSequence :
   public virtual ProbabilisticSequenceInterface,
   public AbstractCoreSequence,
-  public virtual ProbabilisticSymbolList // Diamond inheritence
+  public virtual ProbabilisticSymbolList // Diamond inheritance
 {
 public:
   /**

--- a/src/Bpp/Seq/ProbabilisticSite.h
+++ b/src/Bpp/Seq/ProbabilisticSite.h
@@ -35,7 +35,7 @@ public:
 class ProbabilisticSite :
   public virtual ProbabilisticSiteInterface,
   public AbstractCoreSite,
-  public virtual ProbabilisticSymbolList // Diamond inheritence
+  public virtual ProbabilisticSymbolList // Diamond inheritance
 {
 public:
   /**

--- a/src/Bpp/Seq/ProbabilisticSymbolList.h
+++ b/src/Bpp/Seq/ProbabilisticSymbolList.h
@@ -85,7 +85,7 @@ public:
   ProbabilisticSymbolList(std::shared_ptr<const Alphabet>& alpha);
 
   /**
-   * @brief Build a new ProbabilisticSymbolList object with the specified alphabet and contant as a DataTable.
+   * @brief Build a new ProbabilisticSymbolList object with the specified alphabet and constant as a DataTable.
    *
    * @param list The content of the site.
    * @param alpha The alphabet to use.
@@ -94,7 +94,7 @@ public:
   ProbabilisticSymbolList(const DTable& list, std::shared_ptr<const Alphabet>& alpha);
 
   /**
-   * @brief Build a new ProbabilisticSymbolList object with the specified alphabet and contant as a VVdouble.
+   * @brief Build a new ProbabilisticSymbolList object with the specified alphabet and constant as a VVdouble.
    *
    * @param list The content of the site.
    * @param alpha The alphabet to use.
@@ -120,7 +120,7 @@ public:
   ProbabilisticSymbolList& operator=(const ProbabilisticSymbolListInterface& list);
 
   /**
-   * @brief The assignement operator.
+   * @brief The assignment operator.
    */
   ProbabilisticSymbolList& operator=(const ProbabilisticSymbolList& list);
 

--- a/src/Bpp/Seq/Sequence.h
+++ b/src/Bpp/Seq/Sequence.h
@@ -23,7 +23,7 @@ namespace bpp
  * The states that allowed to be present in the sequence are defined
  * by an alphabet object.
  *
- * Sequence objets also contain a name attribute and potentially several comment lines.
+ * Sequence objects also contain a name attribute and potentially several comment lines.
  * A sequence object is also event-driven, allowing easy extension.
  *
  * @see Alphabet
@@ -52,7 +52,7 @@ public:
    * @brief Set the whole content of the sequence.
    *
    * @param sequence The new content of the sequence.
-   * @see The Sequence constructor for information about the way sequences are internaly stored.
+   * @see The Sequence constructor for information about the way sequences are internally stored.
    */
   virtual void setContent(const std::string& sequence) = 0;
 
@@ -106,7 +106,7 @@ public:
  * For programming convenience, the states are stored as integers, but the translation toward
  * and from a char description is easily performed with the Alphabet classes.
  *
- * Sequence objets also contain a name attribute and potentially several comment lines.
+ * Sequence objects also contain a name attribute and potentially several comment lines.
  *
  * @see Alphabet
  */

--- a/src/Bpp/Seq/SequencePositionIterators.h
+++ b/src/Bpp/Seq/SequencePositionIterators.h
@@ -143,7 +143,7 @@ public:
   SimpleSequencePositionIterator(const Sequence& seq, unsigned int pos = 0) :
     AbstractSequencePositionIterator(seq, pos) {}
   /**
-   * @brief Copie constructor.
+   * @brief Copy constructor.
    *
    * @param it A reference toward a SequencePositionIterator
    */

--- a/src/Bpp/Seq/SequenceTools.cpp
+++ b/src/Bpp/Seq/SequenceTools.cpp
@@ -122,7 +122,7 @@ void SequenceTools::invert(SequenceInterface& seq)
 {
   size_t seq_size = seq.size(); // store seq size for efficiency
   int tmp_state = 0; // to store one state when swapping positions
-  size_t j = seq_size; // symetric position iterator from sequence end
+  size_t j = seq_size; // symmetric position iterator from sequence end
   for (size_t i = 0; i < seq_size / 2; ++i)
   {
     j = seq_size - 1 - i;
@@ -164,7 +164,7 @@ void SequenceTools::invertComplement(SequenceInterface& seq)
   // }
   size_t seq_size = seq.size(); // store seq size for efficiency
   int tmp_state = 0; // to store one state when swapping positions
-  size_t j = seq_size; // symetric position iterator from sequence end
+  size_t j = seq_size; // symmetric position iterator from sequence end
   for (size_t i = 0; i < seq_size / 2; ++i)
   {
     j = seq_size - 1 - i;
@@ -172,7 +172,7 @@ void SequenceTools::invertComplement(SequenceInterface& seq)
     seq.setElement(i, NAR->translate(seq.getValue(j)));
     seq.setElement(j, NAR->translate(tmp_state));
   }
-  if (seq_size % 2)   // treate the state in the middle of odd sequences
+  if (seq_size % 2)   // treat the state in the middle of odd sequences
   {
     seq.setElement(seq_size / 2, NAR->translate(seq.getValue(seq_size / 2)));
   }

--- a/src/Bpp/Seq/SequenceTools.h
+++ b/src/Bpp/Seq/SequenceTools.h
@@ -223,8 +223,8 @@ public:
   /**
    * @brief Inverse and complement a sequence.
    *
-   * This methode is more accurate than calling invert and complement
-   * separatly.
+   * This method is more accurate than calling invert and complement
+   * separately.
    *
    * @param seq The sequence to inverse and complement.
    * @author Sylvain Gaillard
@@ -448,7 +448,7 @@ public:
    * @param motif The motif to find
    * @param strict If true (default) find exactly the motif
    *               If false find compatible match
-   * @return The position of the first occurence of the motif or the seq
+   * @return The position of the first occurrence of the motif or the seq
    * length.
    */
   static size_t findFirstOf(const SequenceInterface& seq, const SequenceInterface& motif, bool strict = true);

--- a/src/Bpp/Seq/SequenceWithAnnotation.h
+++ b/src/Bpp/Seq/SequenceWithAnnotation.h
@@ -44,7 +44,7 @@ public:
    *
    * @param sequence The sequence to be validated against.
    * @param throwException If set to yes, throw an exception if the sequence is not valid.
-   * @return true if this annotation is complient with the given sequence.
+   * @return true if this annotation is compliant with the given sequence.
    */
   virtual bool isValidWith(const SequenceWithAnnotation& sequence, bool throwException = true) const = 0;
 
@@ -52,7 +52,7 @@ public:
    * @brief Merge the input annotation with the current one.
    *
    * @param anno The annotation to fuse.
-   * @return true if the fusion was possible and succesful.
+   * @return true if the fusion was possible and successful.
    */
   virtual bool merge(const SequenceAnnotation& anno) = 0;
 
@@ -75,7 +75,7 @@ public:
  * For programming convenience, the states are stored as integers, but the translation toward
  * and from a char description is easily performed with the Alphabet classes.
  *
- * Sequence objets also contain a name attribute and potentially several comment lines.
+ * Sequence objects also contain a name attribute and potentially several comment lines.
  *
  * The gestion of sequence content is identical to the BasicSequence object, but edition events are
  * properly fired. Listener are therefore properly handled.
@@ -303,7 +303,7 @@ public:
    * @brief Set the whole content of the sequence.
    *
    * @param sequence The new content of the sequence.
-   * @see The Sequence constructor for information about the way sequences are internaly stored.
+   * @see The Sequence constructor for information about the way sequences are internally stored.
    */
   virtual void setContent(const std::string& sequence) override;
 

--- a/src/Bpp/Seq/SequenceWithQuality.h
+++ b/src/Bpp/Seq/SequenceWithQuality.h
@@ -173,7 +173,7 @@ public:
 /**
  * @brief A SequenceWithAnnotation class with quality scores attached.
  *
- * This classes adds some usefull functions to handle quality scores.
+ * This classes adds some useful functions to handle quality scores.
  *
  * @see SequenceQuality
  * @author Sylvain Gaillard, Vincent Cahais, Julien Dutheil
@@ -195,7 +195,7 @@ public:
    *
    * @param alpha    A pointer to an Alphabet
    *
-   * @throw BadCharException if a state is not alowed by the Alphabet
+   * @throw BadCharException if a state is not allowed by the Alphabet
    */
   SequenceWithQuality(
       std::shared_ptr<const Alphabet>& alpha) :
@@ -216,7 +216,7 @@ public:
    * @param sequence The string representing the sequence
    * @param alpha    A pointer to an Alphabet
    *
-   * @throw BadCharException if a state is not alowed by the Alphabet
+   * @throw BadCharException if a state is not allowed by the Alphabet
    */
   SequenceWithQuality(
       const std::string& name,
@@ -240,7 +240,7 @@ public:
    * @param comments Comments to add to the sequence
    * @param alpha    A pointer to an Alphabet
    *
-   * @throw BadCharException if a state is not alowed by the Alphabet
+   * @throw BadCharException if a state is not allowed by the Alphabet
    *
    * @author Vincent Cahais
    */
@@ -267,7 +267,7 @@ public:
    * @param quality The quality scores
    * @param alpha A pointer to an alphabet
    *
-   * @throw BadCharException if a state is not alowed by the Alphabet
+   * @throw BadCharException if a state is not allowed by the Alphabet
    * @throw DimensionException if the number of quality values is not equal
    * to the number of sequence states
    */
@@ -295,7 +295,7 @@ public:
    * @param comments Comments to add to the sequence
    * @param alpha A pointer to an alphabet
    *
-   * @throw BadCharException if a state is not alowed by the Alphabet
+   * @throw BadCharException if a state is not allowed by the Alphabet
    * @throw DimensionException if the number of quality values is not equal
    * to the number of sequence states
    *
@@ -324,7 +324,7 @@ public:
    * @param sequence The sequence in int
    * @param alpha A pointer to an Alphabet
    *
-   * @throw BadIntException if a state is not alowed by the Alphabet
+   * @throw BadIntException if a state is not allowed by the Alphabet
    */
   SequenceWithQuality(
       const std::string& name,
@@ -348,7 +348,7 @@ public:
    * @param comments Comments to add to the sequence
    * @param alpha A pointer to an Alphabet
    *
-   * @throw BadIntException if a state is not alowed by the Alphabet
+   * @throw BadIntException if a state is not allowed by the Alphabet
    *
    * @author Vincent Cahais
    */
@@ -375,7 +375,7 @@ public:
    * @param quality The quality scores
    * @param alpha A pointer to an Alphabet
    *
-   * @throw BadIntException if a state is not alowed by the Alphabet
+   * @throw BadIntException if a state is not allowed by the Alphabet
    * @throw DimensionException if the number of quality values is not equal
    * to the number of sequence states
    */
@@ -403,7 +403,7 @@ public:
    * @param comments Comments to add to the sequence
    * @param alpha A pointer to an Alphabet
    *
-   * @throw BadIntException if a state is not alowed by the Alphabet
+   * @throw BadIntException if a state is not allowed by the Alphabet
    * @throw DimensionException if the number of quality values is not equal
    * to the number of sequence states
    *

--- a/src/Bpp/Seq/StringSequenceTools.cpp
+++ b/src/Bpp/Seq/StringSequenceTools.cpp
@@ -297,7 +297,7 @@ std::shared_ptr<const Alphabet> StringSequenceTools::getAlphabetFromSequence(con
   }
 
   if (u)
-    throw Exception("Sequence::getAlphabetFromSequence : Unknow character detected in specified sequence");
+    throw Exception("Sequence::getAlphabetFromSequence : Unknown character detected in specified sequence");
   if (r && pd)
     throw Exception("Sequence::getAlphabetFromSequence : Both 'T' and 'U' in the same sequence!");
   if (r && p)

--- a/src/Bpp/Seq/StringSequenceTools.h
+++ b/src/Bpp/Seq/StringSequenceTools.h
@@ -39,7 +39,7 @@ public:
    * @brief Get a subsequence.
    *
    * @param sequence The input sequence.
-   * @param begin    The begining position (included).
+   * @param begin    The beginning position (included).
    * @param end      The ending position (included).
    * @return A string with the subsequence.
    * @throw Exception If position does not not match the interval [0, length].
@@ -69,7 +69,7 @@ public:
   static std::string setToSizeL(const std::string& sequence, size_t size);
 
   /**
-   * @brief Delete all occurence of a character in the sequence.
+   * @brief Delete all occurrence of a character in the sequence.
    *
    * @param sequence The sequence to parse.
    * @param chars    The character to remove.
@@ -78,7 +78,7 @@ public:
   static std::string deleteChar(const std::string& sequence, char chars);
 
   /**
-   * @brief Delete all occurence of several characters in the sequence.
+   * @brief Delete all occurrence of several characters in the sequence.
    *
    * @param sequence The sequence to parse.
    * @param chars    The characters to remove.

--- a/src/Bpp/Seq/SymbolList.h
+++ b/src/Bpp/Seq/SymbolList.h
@@ -24,7 +24,7 @@ namespace bpp
 /**
  * @brief A partial implementation of a SymbolList object.
  *
- * This class implements most of the CoreSymbolList interface, with the excpetion of the getStateValueAt function, which depend on the template type.
+ * This class implements most of the CoreSymbolList interface, with the exception of the getStateValueAt function, which depend on the template type.
  *
  * @see Alphabet
  */
@@ -198,14 +198,14 @@ public:
 /**
  * @brief A partial implementation of a EventDrivenSymbolList object.
  *
- * This class implements most of the CoreSymbolList interface, with the excpetion of the getStateValueAt function, which depend on the template type.
+ * This class implements most of the CoreSymbolList interface, with the exception of the getStateValueAt function, which depend on the template type.
  *
  * @see Alphabet
  */
 template<class T>
 class AbstractTemplateEventDrivenSymbolList :
   public virtual AbstractTemplateSymbolList<T>,
-  // Note: this needs to be virtual because of diamond inheritence
+  // Note: this needs to be virtual because of diamond inheritance
   public virtual TemplateEventDrivenCoreSymbolListInterface<T>
 {
 private:

--- a/src/Bpp/Seq/SymbolListTools.h
+++ b/src/Bpp/Seq/SymbolListTools.h
@@ -144,7 +144,7 @@ public:
 
   /**
    * @param site A site.
-   * @return True if the site contains one or several unknwn characters.
+   * @return True if the site contains one or several unknown characters.
    */
   static bool hasUnknown(const IntSymbolListInterface& site);
   static bool hasUnknown(const ProbabilisticSymbolListInterface& site);
@@ -347,7 +347,7 @@ public:
 
 
   /**
-   * @brief Count all states in the list, optionaly resolving unknown characters.
+   * @brief Count all states in the list, optionally resolving unknown characters.
    *
    * For instance, in DNA, N will be counted as A=1/4,T=1/4,C=1/4,G=1/4.
    *
@@ -495,7 +495,7 @@ public:
       std::map< int, std::map<int, double>>& counts);
 
   /**
-   * @brief Count all pairs of states for two lists of the same size, optionaly resolving unknown characters.
+   * @brief Count all pairs of states for two lists of the same size, optionally resolving unknown characters.
    *
    * For instance, in DNA, N will be counted as A=1/4,T=1/4,C=1/4,G=1/4.
    *

--- a/test/test_alphabets.cpp
+++ b/test/test_alphabets.cpp
@@ -16,7 +16,7 @@ using namespace std;
 
 int main()
 {
-  // This is a very simple test that instanciate all alphabet classes.
+  // This is a very simple test that instantiate all alphabet classes.
   auto dna = std::make_shared<DNA>();
   auto rna = std::make_shared<RNA>();
   auto pro = std::make_shared<ProteicAlphabet>();


### PR DESCRIPTION
Some where found by the quality assurance checks for the Debian package of bpp-seq, the rest by running the tool `codespell` and reviewing the results.
